### PR TITLE
fix(coinjon): using coin_control to limit inputs for CJ transactions

### DIFF
--- a/dash-spv-coinjoin/src/ffi/callbacks.rs
+++ b/dash-spv-coinjoin/src/ffi/callbacks.rs
@@ -49,7 +49,7 @@ pub type IsMineInput = unsafe extern "C" fn(
 
 pub type AvailableCoins = unsafe extern "C" fn(
     only_safe: bool,
-    coin_control: CoinControl,
+    coin_control: *mut CoinControl,
     wallet_ex: &mut WalletEx,
     context: *const c_void,
 ) -> *mut GatheredOutputs;
@@ -84,6 +84,7 @@ pub type FreshCoinJoinAddress = unsafe extern "C" fn(
 pub type CommitTransaction = unsafe extern "C" fn(
     items: *mut *mut Recipient,
     item_count: usize,
+    coin_control: *mut CoinControl,
     is_denominating: bool,
     client_session_id: *mut [u8; 32],
     context: *const c_void

--- a/dash-spv-coinjoin/src/ffi/coin_control.rs
+++ b/dash-spv-coinjoin/src/ffi/coin_control.rs
@@ -1,10 +1,14 @@
 use crate::models::coin_control::CoinType;
 
+use super::tx_outpoint::TxOutPoint;
+
 #[repr(C)]
 pub struct CoinControl {
     pub coin_type: CoinType,
     pub min_depth: i32,
     pub max_depth: i32,
     pub avoid_address_reuse: bool,
-    pub allow_other_inputs: bool
+    pub allow_other_inputs: bool,
+    pub set_selected: *mut *mut TxOutPoint,
+    pub set_selected_size: usize,
 }

--- a/dash-spv-coinjoin/src/ffi/mod.rs
+++ b/dash-spv-coinjoin/src/ffi/mod.rs
@@ -8,3 +8,4 @@ pub mod gathered_outputs;
 pub mod input_value;
 pub mod socket_addres;
 pub mod coinjoin_keys;
+pub mod tx_outpoint;

--- a/dash-spv-coinjoin/src/ffi/tx_outpoint.rs
+++ b/dash-spv-coinjoin/src/ffi/tx_outpoint.rs
@@ -1,0 +1,16 @@
+use crate::models::tx_outpoint as tx_outpoint;
+
+#[repr(C)]
+pub struct TxOutPoint {
+    pub hash: [u8; 32],
+    pub index: u32,
+}
+
+impl From<tx_outpoint::TxOutPoint> for TxOutPoint {
+    fn from(outpoint: tx_outpoint::TxOutPoint) -> Self {
+        TxOutPoint {
+            hash: outpoint.hash.0,
+            index: outpoint.index,
+        }
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Inputs for CoinJoin transactions are taken from already-denominated inputs which is an error.


## What was done?
Leverage CoinControll to limit inputs while forming a transaction.


## How Has This Been Tested?
N/A


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone